### PR TITLE
Replace "pycrypto" with "pycryptodome"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Release Notes
 =============
 
+2.0.4 - Updated crypto libary
+-----------------------------
+*  Replaced "pycrypto" libary with "pycryptodome" libary. 
+
 2.0.3 - Updated documentation
 -----------------------------
 *  Updated documentation to be compatible with *Python 3*.

--- a/lib/truepy/_info.py
+++ b/lib/truepy/_info.py
@@ -1,4 +1,4 @@
 # coding: utf8
 
 __author__ = u'Moses Palmér'
-__version__ = (2, 0, 3)
+__version__ = (2, 0, 4)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ PACKAGE_DIR = {
 
 REQUIREMENTS = [
     'cryptography >=1.0',
-    'pycrypto >=2.6.1']
+    'pycryptodome >=3.9.4']
 
 
 def setup(**kwargs):


### PR DESCRIPTION
"pycrypto" is not maitained very very long ago. Too many fails for python 3.x (after 3.5), later window (higher VS) if installing truepy . Even you can not find a compiled binaries on http://www.voidspace.org.uk/python/modules.shtml#pycrypto .

So it's better to replace it. I ran all unittests.